### PR TITLE
[VER-16] Build app as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,35 @@ jobs:
             ./gradlew assembleRelease
       - store_artifacts:
           path: app/build/outputs/apk/release/app-release-unsigned.apk
+  debug-build:
+    executor:
+      name: android/android-machine
+      resource-class: large
+      tag: 2021.12.1
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - android/restore-build-cache
+      - run:
+          name: Assemble debug build
+          command: |
+            ./gradlew assembleDebug
+      - store_artifacts:
+          path: app/build/outputs/apk/debug/app-debug-unsigned.apk
+      - android/save-gradle-cache
+      - android/save-build-cache
 
 workflows:
   test-and-build:
     jobs:
       - lint-kotlin
-      - unit-test
+      - debug-build
+      - unit-test:
+          requires:
+            - debug-build
       - android/run-ui-tests:
+          requires:
+            - debug-build
           filters:
             branches:
               ignore: main # regular commits
@@ -96,6 +118,8 @@ workflows:
             resource-class: large
             tag: 2021.12.1
       - android-test:
+          requires:
+            - debug-build
           matrix:
             alias: android-test-all
             parameters:


### PR DESCRIPTION
Builds the debug APK first before running any tests. This should give us extra confidence in the build, as well as optimizing CI, as we're not building the app twice in parallel anymore.