### PR TITLE
comment-score-hidden-and-edit-times

### DIFF
--- a/db/schemas/com.neaniesoft.vermilion.db.VermilionDatabase/16.json
+++ b/db/schemas/com.neaniesoft.vermilion.db.VermilionDatabase/16.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 15,
+    "version": 16,
     "identityHash": "cfb40662218efc3b0a02644dbc9fb113",
     "entities": [
       {

--- a/db/src/main/java/com/neaniesoft/vermilion/db/VermilionDatabase.kt
+++ b/db/src/main/java/com/neaniesoft/vermilion/db/VermilionDatabase.kt
@@ -27,7 +27,7 @@ import com.neaniesoft.vermilion.dbentities.useraccount.UserAccountRecord
         CommunityRecord::class,
         PostHistoryRecord::class
     ],
-    version = 15
+    version = 16
 )
 abstract class VermilionDatabase : RoomDatabase() {
     abstract fun userAccountDao(): UserAccountDao

--- a/dbentities/src/main/java/com/neaniesoft/vermilion/dbentities/comments/CommentRecord.kt
+++ b/dbentities/src/main/java/com/neaniesoft/vermilion/dbentities/comments/CommentRecord.kt
@@ -15,6 +15,7 @@ data class CommentRecord(
     val flags: String,
     val author: String,
     val createdAt: Long,
+    val editedAt: Long,
     val insertedAt: Long,
     val score: Int,
     val link: String,

--- a/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/data/CommentRepository.kt
+++ b/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/data/CommentRepository.kt
@@ -230,6 +230,11 @@ class CommentRepositoryImpl @Inject constructor(
             authorName = AuthorName(author),
             createdAt = Instant.ofEpochMilli(createdAt),
             createdAtDurationString = createdAt.formatDuration(),
+            editedAt = if (editedAt > 0) {
+                Instant.ofEpochMilli(editedAt)
+            } else {
+                null
+            },
             score = Score(score),
             link = link.toUri(),
             postId = PostId(postId),
@@ -332,6 +337,7 @@ class CommentRepositoryImpl @Inject constructor(
             author = "",
             createdAt = now,
             insertedAt = now,
+            editedAt = 0,
             score = count, // TODO this is pretty gross, using the score field to store the child count. Should probably modify the schema to allow for this new field instead.
             link = "",
             controversialIndex = 0,
@@ -392,6 +398,7 @@ class CommentRepositoryImpl @Inject constructor(
             flags = flags,
             author = author,
             createdAt = createdUtc.toLong(),
+            editedAt = edited.toLong(),
             insertedAt = clock.millis(),
             score = score,
             link = permalink,

--- a/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/data/CommentRepository.kt
+++ b/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/data/CommentRepository.kt
@@ -235,6 +235,11 @@ class CommentRepositoryImpl @Inject constructor(
             } else {
                 null
             },
+            editedAtDurationString = if (editedAt > 0) {
+                editedAt.formatDuration()
+            } else {
+                null
+            },
             score = Score(score),
             link = link.toUri(),
             postId = PostId(postId),

--- a/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/domain/entities/Comment.kt
+++ b/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/domain/entities/Comment.kt
@@ -15,6 +15,7 @@ data class Comment(
     val authorName: AuthorName,
     val createdAt: Instant,
     val createdAtDurationString: DurationString,
+    val editedAt: Instant?,
     val score: Score,
     val link: Uri,
     val postId: PostId,

--- a/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/domain/entities/Comment.kt
+++ b/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/domain/entities/Comment.kt
@@ -16,6 +16,7 @@ data class Comment(
     val createdAt: Instant,
     val createdAtDurationString: DurationString,
     val editedAt: Instant?,
+    val editedAtDurationString: DurationString?,
     val score: Score,
     val link: Uri,
     val postId: PostId,

--- a/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/ui/CommentRow.kt
+++ b/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/ui/CommentRow.kt
@@ -97,7 +97,11 @@ fun CommentRow(
                     CommentFlair(flair = comment.commentFlair, Modifier.padding(end = 8.dp))
 
                     val score = remember {
-                        NumberFormat.getIntegerInstance().format(comment.score.value)
+                        if (comment.flags.contains(CommentFlags.SCORE_HIDDEN)) {
+                            "?"
+                        } else {
+                            NumberFormat.getIntegerInstance().format(comment.score.value)
+                        }
                     }
 
                     Text(

--- a/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/ui/CommentRow.kt
+++ b/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/ui/CommentRow.kt
@@ -319,6 +319,7 @@ private val DUMMY_COMMENT = Comment(
     AuthorName("Some user"),
     Instant.now(),
     DurationString("1h ago"),
+    null,
     Score(1024),
     "".toUri(),
     PostId("post_id"),

--- a/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/ui/CommentRow.kt
+++ b/postdetails/src/main/java/com/neaniesoft/vermilion/postdetails/ui/CommentRow.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -113,10 +114,21 @@ fun CommentRow(
                     )
                     CommentFlagIcons(flags = comment.flags)
                     Spacer(modifier = Modifier.weight(1.0f))
-                    Text(
-                        text = comment.createdAtDurationString.value,
-                        style = MaterialTheme.typography.caption,
-                    )
+                    Column(horizontalAlignment = Alignment.End) {
+
+                        Text(
+                            text = comment.createdAtDurationString.value,
+                            style = MaterialTheme.typography.caption,
+                        )
+                        if (comment.editedAtDurationString != null) {
+                            Text(
+                                text = "edited ${comment.editedAtDurationString.value}",
+                                style = MaterialTheme.typography.caption,
+                                fontStyle = FontStyle.Italic,
+                                modifier = Modifier.padding(top = 4.dp)
+                            )
+                        }
+                    }
                 }
 
                 Box(Modifier.padding(top = 8.dp)) {
@@ -310,6 +322,16 @@ fun OpCommentRowPreview() {
     }
 }
 
+@Preview
+@Composable
+fun EditedCOmmentRowPreview() {
+    VermilionTheme(darkTheme = true) {
+        Surface {
+            CommentRow(EDITED_DUMMY_COMMENT)
+        }
+    }
+}
+
 private val DUMMY_COMMENT = Comment(
     CommentId("id"),
     CommentContent("This is a pretty long comment that might split over several lines. It's got several sentences and goes on for some time. Still going here."),
@@ -319,6 +341,7 @@ private val DUMMY_COMMENT = Comment(
     AuthorName("Some user"),
     Instant.now(),
     DurationString("1h ago"),
+    null,
     null,
     Score(1024),
     "".toUri(),
@@ -341,3 +364,8 @@ private val STICKED_MOD_DUMMY_COMMENT =
     DUMMY_COMMENT.copy(flags = setOf(CommentFlags.STICKIED, CommentFlags.IS_MOD))
 private val ADMIN_DUMMY_COMMENT = DUMMY_COMMENT.copy(flags = setOf(CommentFlags.IS_ADMIN))
 private val OP_DUMMY_CONTENT = DUMMY_COMMENT.copy(flags = setOf(CommentFlags.IS_OP))
+private val EDITED_DUMMY_COMMENT = DUMMY_COMMENT.copy(
+    flags = setOf(CommentFlags.EDITED),
+    editedAt = Instant.now(),
+    editedAtDurationString = DurationString("moments ago")
+)


### PR DESCRIPTION
Hides comment scores when the API dictates they should be hidden. Also display edited time on edited comments

Fixes #126 
Fixes #129 